### PR TITLE
Add pronouns to speedcontrol types

### DIFF
--- a/schemas/lib/speedcontrolPlayer.json
+++ b/schemas/lib/speedcontrolPlayer.json
@@ -15,6 +15,9 @@
 		"country": {
 			"type": "string"
 		},
+		"pronouns": {
+			"type": "string"
+		},
 		"social": {
 			"type": "object",
 			"additionalProperties": false,

--- a/src/nodecg/external/speedcontrol/RunData.d.ts
+++ b/src/nodecg/external/speedcontrol/RunData.d.ts
@@ -26,6 +26,7 @@ export interface RunData {
 			id: string;
 			teamID: string;
 			country?: string;
+			pronouns?: string;
 			social: {
 				twitch?: string;
 			};


### PR DESCRIPTION
speedcontrol v2.3.0から`pronouns`(代名詞 e.g. he/him)がRunDataに追加された為対応しました。
ビルドの成果物はコミットに含めていません。
まだspeedcontrolをv2.2.x等で動作させたい場合などは保留して頂いて構いません。